### PR TITLE
Corrigi bug de não mover itens para remains

### DIFF
--- a/pkg/items/containers/corpse/canInsert.src
+++ b/pkg/items/containers/corpse/canInsert.src
@@ -9,7 +9,7 @@ program canRemove(character, container, item, move_type)
 	elseif (character.frozen || character.paralyzed)
 		SendSysMessage(character, "Voce esta paralizado.");
 		return 0;
-	elseif (container.objtype == 0xEFFF)
+	elseif (container.objtype == 0xEFFF && GetObjProperty(container, "allow_temp_move") != 1)
 		SendSysMessage(character, "E impossivel adicionar itens a restos mortais.");
 		return 0;
 	else

--- a/pkg/items/containers/corpse/methods.src
+++ b/pkg/items/containers/corpse/methods.src
@@ -82,12 +82,20 @@ exported function MakeRemains(corpse)
 			return remains;
 		endif
 
+		//Adiciona propriedade para permitir mover os itens para um remains
+        SetObjProperty(remains, "allow_temp_move", 1);
+
 		foreach item in ( EnumerateItemsInContainer(corpse) )
 			if ( item.container != corpse )
 				continue;
 			endif
 
-			MoveItemToContainer(item, remains, item.x, item.y);
+            var errorMoveItemToContainer := MoveItemToContainer(item, remains, item.x, item.y);
+            if (!errorMoveItemToContainer)
+                Syslog("Erro ao mover o item para o remains: " + errorMoveItemToContainer.errortext);
+            endif
+
+			item.decayAt := 0;
 		endforeach
 
 		var realowner := IsPlayerCorpse(corpse);
@@ -105,7 +113,8 @@ exported function MakeRemains(corpse)
 			SetName(remains, "Restos de Corpo");
 		endif
 
-
+        //Não permite inserir mais itens nos remains, após mover os itens do body -> remains
+        EraseObjProperty(remains, "allow_temp_move");
 
 		DestroyItem(corpse);
 

--- a/pkg/items/containers/corpse/use.src
+++ b/pkg/items/containers/corpse/use.src
@@ -1,0 +1,11 @@
+use uo;
+use os;
+
+include ":containers:useCorpse";
+
+program useScript_Corpse( mobile, corpse )
+
+        SetObjProperty( corpse, "#CorpseUsed", 1 );
+
+        return OpenContainer( mobile, corpse );
+endprogram

--- a/pkg/items/containers/include/useCorpse.inc
+++ b/pkg/items/containers/include/useCorpse.inc
@@ -1,0 +1,41 @@
+use uo;
+use os;
+
+//include ":areas:managment";		// Pkg required by Destiny's Reach scripts. ?Might implement later.
+
+function OpenContainer( mobile, corpse )
+
+	var owner := corpse.GetOwner();
+	if( !owner )
+		// No owner. Could be deleted or an NPC corpse.
+	        return SendViewContainer( mobile, corpse );
+	elseif( owner == mobile )
+		// Owner is looting his/her own stuff.
+	        return SendViewContainer( mobile, corpse );
+	elseif( IsGuildMember( mobile, owner ))
+	        return SendViewContainer( mobile, corpse );
+// The following required by Destiny's Reach scripts.
+// I might implement the 'areas' pkg later.
+/*        elseif( A_IsIn( corpse, AREAS_NO_LOOTING ))
+                if( owner.criminal || owner.murderer )
+                        if( A_IsIn( corpse, AREAS_NO_DAMAGE ))
+		                return 0;
+                        endif
+	                return SendViewContainer( mobile, corpse );
+                endif
+		return 0; */
+        endif
+
+	return SendViewContainer( mobile, corpse );
+endfunction
+
+function IsGuildMember( mobile, owner )
+
+	// This should probably exist in a guilds include file.
+	if( owner.Guildid == mobile.Guildid )
+		// Both are members of the same guild.
+		return 1;
+	endif
+
+	return 0;
+endfunction


### PR DESCRIPTION
- Criada propriedade para deixar mover os itens enquanto criar o remains e move os itens
- Adicionado tratamento para caso a propriedade já tenha sido apagada e usar a lógica anterior
- Adicionado syslog para caso dê algum erro para mover os itens, melhorando o debug futuro
- Criado arquivos que estavam faltando e dava alguns erros no console